### PR TITLE
Remove greeting from first example

### DIFF
--- a/docs/guides/compile-and-run.html
+++ b/docs/guides/compile-and-run.html
@@ -42,7 +42,6 @@
 <p>All Emojicode source files are named like <code>file.emojic</code>. So let’s get started by creating a file called <code>greeter.emojic</code> and put some content into it:</p>
 <pre><code>🐇 🐼 🍇
   🐇🐖 🏁 ➡️ 🚂 🍇
-    😀 🔤￼Howdy, partner!🔤
     🍎 0
   🍉
 🍉


### PR DESCRIPTION
This line/syntax is only introduced later in the guide and should not appear in the first example.
