### PR TITLE
fix typo in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
         <div class="u-1-2">
           <div class="feature-circle"><img src="img/1f4e6.svg"></div>
           <h2>Packages.</h2>
-          <p>Emojicode has got a read-to-use package system to access every part of the system.</p>
+          <p>Emojicode has got a ready-to-use package system to access every part of the system.</p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Changing 'read-to-use' to 'ready-to-use'. 
