### PR TITLE
Fix typos in classes page

### DIFF
--- a/docs/reference/classes.html
+++ b/docs/reference/classes.html
@@ -207,7 +207,7 @@ defined. Subclasses can’t access their superclasses instance variables.</p>
   👴 code to send an email, sets variable emailSent?
   🍎 emailSent?
 🍉
-</code></pre><p>This method is named ✉️ and takes to arguments: <code>to</code> and <code>subject</code>. It returns a 👌.</p>
+</code></pre><p>This method is named ✉️ and takes two arguments: <code>to</code> and <code>subject</code>. It returns a 👌.</p>
 <h3 id="calling-methods">Calling Methods</h3>
 <p>The syntax to call a method is a bit different:</p>
 <pre><code>methodEmoji object [arguments ...]
@@ -271,9 +271,9 @@ defined. Subclasses can’t access their superclasses instance variables.</p>
 <h2 id="overriding-methods-and-initializers">Overriding Methods and Initializers</h2>
 <p>You can override methods and initializers by redeclaring them in a subclass leaded by ✒️.</p>
 <h3 id="promises">Promises</h3>
-<p>You must watch out not break the superclass’s <em>promises</em>. Promises are a set of rules that ensure that the class’s routines can be used the same way as its superclass’s routines – a main characteristic of object orientation. These promises are:</p>
+<p>You must watch out not to break the superclass’s <em>promises</em>. Promises are a set of rules that ensure that the class’s routines can be used the same way as its superclass’s routines – a main characteristic of object orientation. These promises are:</p>
 <ul>
-<li>The new routine must the take the same number of arguments.</li>
+<li>The new routine must take the same number of arguments.</li>
 <li>The return type of the new routine must be the same or a subtype of the super method’s return type.</li>
 <li>The arguments of the new routine must be of the same type or a super type of the super method’s argument type.</li>
 </ul>


### PR DESCRIPTION
Issues outlined https://github.com/emojicode/emojicode/issues/29

"This method is named ✉ and takes to arguments: to and subject. It returns a 👌." = "two arguments"
"You must watch out not break the superclass’s promises." = "not to"?
"The new routine must the take the same number of arguments." = "must take"
