### PR TITLE
Add an Input Methods guide to help newcomers type faster

### DIFF
--- a/docs/guides/compile-and-run.html
+++ b/docs/guides/compile-and-run.html
@@ -37,6 +37,9 @@
             <li><a href="#what-to-do-next">What to do next</a></li>
           </ul>
       </li>
+    	<li>
+        <a href="input-methods.html">Input methods</a>
+      </li>
 	</ol>
 </div>
 
@@ -157,6 +160,9 @@ miss Emojicode’s incredible power if you don’t.</p>
 	<div class="reference-navigation-bottom">
 		<a href="install.html" class="left">
 			← Previous
+		</a>
+		<a href="input-methods.html" class="right">
+			Next →
 		</a>
 	</div>
 </div>

--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -35,6 +35,9 @@
     	<li>
         <a href="compile-and-run.html">Compile and Run Your First Program</a>
       </li>
+    	<li>
+        <a href="input-methods.html">Input methods</a>
+      </li>
 	</ol>
 </div>
 

--- a/docs/guides/input-methods.html
+++ b/docs/guides/input-methods.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+		<link href="..&#x2F;static/css/style.css" rel="stylesheet" />
+		<title>Emojicode Documentation &middot; Input methods</title>
+	</head>
+	<body>
+		<div class="global-nav">
+			Help and more at <a href="http://emojicode.org">emojicode.org</a>.
+		</div>
+		<nav class="navbar" role="navigation">
+			<a href="..&#x2F;" class="logo">
+        Emojicode Documentation
+      </a>
+      <div class="navbar-right">
+	      <a href="..&#x2F;">Home</a>
+	      <a href="..&#x2F;guides">Guides</a>
+				<a href="..&#x2F;reference">Language Reference</a>
+				<a href="..&#x2F;packages">Package Index</a>
+			</div>
+		</nav>
+
+		<div class="toc fixed">
+	<h2>Emojicode Guides</h2>
+	<ol>
+    	<li>
+        <a href="install.html">Installing Emojicode</a>
+      </li>
+    	<li>
+        <a href="compile-and-run.html">Compile and Run Your First Program</a>
+      </li>
+    	<li>
+        <a href="input-methods.html">Input methods</a>
+          <ul>
+            <li><a href="#ibus">IBus</a></li>
+            <li><a href="#compose-hex-code-">Compose (Hex code)</a></li>
+          </ul>
+      </li>
+	</ol>
+</div>
+
+<div class="content">
+	<h1 id="input-methods">Input methods</h1>
+<p>So, you&#39;ve installed Emojicode and are willing to spend the rest of the weekend and maybe your life programming with it. It is a language crafted by Gods, you think. But, suddendly, a realization comes to you. Your keyboard has no worthy symbols. Just those letters you used for your old programming activities.</p>
+<p>Do not fear, for Gods where not crazy when they crafted Emojicode, they also created input methods and shortcuts so you could code in this beautiful language.</p>
+<h2 id="ibus">IBus</h2>
+<p>Available for GNU/Linux and other *nix-like OSes, this input method, when correctly configured will let you switch between Emojis and other, not so worthy, things.</p>
+<p>If you happen to run Arch Linux you would have to follow this:  <a href="https://wiki.archlinux.org/index.php/IBus">https://wiki.archlinux.org/index.php/IBus</a> and then install the AUR <code>ibus-uniemoji-git</code> package. If you have problems with any package after doing so, reinstall <code>gtk2</code>.</p>
+<p>For other OSes, the installation is similar. Please do refer to your OS documentation.</p>
+<h2 id="compose-hex-code-">Compose (Hex code)</h2>
+<p>Although less user-friendly, it might feel more hacky for you. Just hit <code>ctrl</code> + <code>shift</code> + <code>u</code>, type the hex code of the Emoji and then press <code>enter</code>.</p>
+
+
+	<div class="reference-navigation-bottom">
+		<a href="compile-and-run.html" class="left">
+			← Previous
+		</a>
+	</div>
+</div>
+
+
+		<script type="text/javascript">
+			if(navigator.platform.indexOf('Mac') == -1 && navigator.platform.indexOf('iPhone') == -1
+			&& navigator.platform.indexOf('iPad') == -1 && navigator.platform.indexOf('iPod') == -1){
+				twemoji.parse(document.body);
+			}
+		</script>
+	</body>
+</html>

--- a/docs/guides/install.html
+++ b/docs/guides/install.html
@@ -35,6 +35,9 @@
     	<li>
         <a href="compile-and-run.html">Compile and Run Your First Program</a>
       </li>
+    	<li>
+        <a href="input-methods.html">Input methods</a>
+      </li>
 	</ol>
 </div>
 

--- a/src/guides/chapters.json
+++ b/src/guides/chapters.json
@@ -1,4 +1,5 @@
 [
   "install.md",
-  "compile-and-run.md"
+  "compile-and-run.md",
+  "input-methods.md"
 ]

--- a/src/guides/input-methods.md
+++ b/src/guides/input-methods.md
@@ -1,0 +1,18 @@
+# Input methods
+
+So, you've installed Emojicode and are willing to spend the rest of the weekend and maybe your life programming with it. It is a language crafted by Gods, you think. But, suddendly, a realization comes to you. Your keyboard has no worthy symbols. Just those letters you used for your old programming activities.
+
+Do not fear, for Gods where not crazy when they crafted Emojicode, they also created input methods and shortcuts so you could code in this beautiful language.
+
+## IBus
+
+Available for GNU/Linux and other *nix-like OSes, this input method, when correctly configured will let you switch between Emojis and other, not so worthy, things.
+
+If you happen to run Arch Linux you would have to follow this:  [https://wiki.archlinux.org/index.php/IBus](https://wiki.archlinux.org/index.php/IBus) and then install the AUR `ibus-uniemoji-git` package. If you have problems with any package after doing so, reinstall `gtk2`.
+
+For other OSes, the installation is similar. Please do refer to your OS documentation.
+
+## Compose (Hex code)
+
+Although less user-friendly, it might feel more hacky for you. Just hit `ctrl` + `shift` + `u`, type the hex code of the Emoji and then press `enter`.
+


### PR DESCRIPTION
As proposed by @idmean, I created a PR with an Input Methods Guide (thought that would be the best place to put it). The guide covers both IBus and the Compose method. I already compiled the docs, so no need to do it again ;). Happy Hacking ❤!
