### PR TITLE
Fixing typos!

### DIFF
--- a/docs/guides/compile-and-run.html
+++ b/docs/guides/compile-and-run.html
@@ -196,7 +196,7 @@ evelopmentday
 omputercay
 </code></pre><p>Cool! We have successfully translated English words into Pig Latin.</p>
 <h2 id="what-to-do-next">What to do next</h2>
-<p>I highly recommend you to read through the <a href="../reference">Language Reference</a>
+<p>I highly recommend you read through the <a href="../reference">Language Reference</a>
 which is a bit more formal but also a really good starting point.</p>
 <div class="callout-hint"><div class="title">Hint</div>          <div class="text"><p>You should really read the <a href="../reference">Language Reference</a>, you gonna
 miss Emojicode’s incredible power if you don’t.</p>

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
           <p>
             Emojicode binaries run on the so called Real-Time Engine which
             <b>works across platforms</b>. You can use it on OS X, Ubuntu,
-            Debian, Raspbian,
+            Debian, Raspbian...
           </p>
         </div>
 


### PR DESCRIPTION
Hi there! Just fixing a couple of typos here, including:
- a comma causing ambiguity on the homepage, which I changed back to [the ellipsis that was there before](https://github.com/emojicode/emojicode.github.io/commit/2bea3626273902c62c7cb91e2a66f75f06590f1f#diff-eacf331f0ffc35d4b482f1d15a887d3bL75)
- an unnecessary word in the Compile and Run guide

Thanks ✅ ❤️ 
