### PR TITLE
Optionals documentation - fix spelling, more emoji

### DIFF
--- a/src/reference/optionals.md
+++ b/src/reference/optionals.md
@@ -18,31 +18,31 @@ used in conjunction with *Optionals*.
 ## 🍬 Optionals
 
 An optional is a way to make a type optional. This is like saying: either it’s
-something of the delcared type, or it’s Nothingness. Optionals are very userful
-in cases where a value might be missing or a method migh fail and return nothing
-instead of a expected value.
+something of the declared type, or it’s ⚡. Optionals are very useful
+in cases where a value might be missing or a method might fail and 🍎 nothing
+instead of an expected value.
 
-To make a type optional you need to prepend a 🍬. Examples:
+To make a type optional you need to prepend it with a 🍬. Examples:
 
 ```
 🍰 buildingAge 🍬🚂 👴The age of old buildings is often not known exactly.
 🍰 petName 🍬🔡 👴Some pets have no name.
 ```
 
-There are many methods that return Nothingness on failure. For instance the
-method 🔬 of 🔡, which returns the symbol at the given index or Nothingness.
+There are many methods that return ⚡ on failure. For instance the
+method 🔬 of 🔡, which returns the 🔣 at the given index or ⚡.
 
 ```
 🍦 first 🔬 🔤Kumquat🔤 0
 🍦 twelfth 🔬 🔤Kumquat🔤 11
 ```
 
-As you can see `first` will now actually contain a symbol and `twelfth` will
-only contain Nothingness.
+As you can see `first` will now actually contain a 🔣 and `twelfth` will
+only contain ⚡.
 
 The point of Optionals is providing more safety. This is achieved by forcing
 the programmer to take special care of optionals as optionals cannot be used
-like the they make optionals.
+like the type they make optional.
 
 ## 🍺 Unwrapping
 
@@ -53,8 +53,8 @@ you could unwrap the optional using 🍺:
 $unwrap$-> 🍺 $expression$
 </pre>
 
-This tells Emojicode to check that *value* is not Nothingness and
-returns it. If the value, however, is Nothingness the program will terminate
+This tells Emojicode to check that *value* is not ⚡ and
+returns it. If the value, however, is ⚡, the program will terminate
 with an error message like:
 
 ```
@@ -66,20 +66,20 @@ be done. See the sections below for safe ways.
 
 ## ☁️ Nothingness Test
 
-You can use ☁️ to test if an optional is Nothingness.
+You can use ☁️ to test if an optional is ⚡.
 
 <pre class="syntax">
 $is-nothingness$-> ☁️ $expression$
 </pre>
 
-☁️ returns true if the expression is Nothingness.
+☁️ returns 👍 if the expression is ⚡.
 
 ## 🍊🍦 Condition Assignment
 
-An even more useful way to protect from Nothingness is the Condition Assingment.
+An even more useful way to protect from ⚡ is the Condition Assingment.
 You can use 🍦 in conditions, that is in combination with 🍊, 🍋 or 🔁, and the
-conidition will be true if the value provided for the variable is not
-Nothingness. In that case, the variable *variable* will be set to the unwrapped
+conidition will be 👍 if the value provided for the variable is not
+✨. In that case, the variable *variable* will be set to the unwrapped
 value.
 
 Take a look at this example:
@@ -91,4 +91,4 @@ Take a look at this example:
 ```
 
 The block of the 🍊 statement will only be executed if `🔲 sth 🔡` does not
-evaluate to Nothingness.
+evaluate to ✨.


### PR DESCRIPTION
On ⚡ vs ✨: ✨ is a type and should be used to describe a method that doesn't return anything. Think about it like `void`. ⚡ is a value that an optional can take, think about it like null. ⚡ is used way more than ✨ on this page, but I think this is a good thing - ⚡ was harder for me to remember than ✨.