### PR TITLE
Fix the supermethod call example

### DIFF
--- a/src/reference/inheritance.md
+++ b/src/reference/inheritance.md
@@ -75,7 +75,7 @@ As for example:
 🐇 🌻 🌼 🍇
   ✒️ 🐖 ⏰ time 🚂 🍇
     👴 Sunflowers also rotate to face the sun....
-    🐿 ⏰ 👴 Open and close like other flowers; see below
+    🐿 ⏰ time 👴 Open and close like other flowers; see below
   🍉
 🍉
 ```


### PR DESCRIPTION
I assume that the arguments won't be provided automatically. If I'm wrong, I suggest adding an explaination about this shorthand.