### PR TITLE
Byte range

### DIFF
--- a/src/reference/basics.md
+++ b/src/reference/basics.md
@@ -86,7 +86,7 @@ There are only three numeric types in Emojicode:
 - 🔢 represents integer in the interval [-2<sup>63</sup>+1,
 2<sup>63</sup>-1].
 - 💯 represents real numbers (numbers with decimal place).
-- 💧 represents bytes, which are integers in the range of [-127,127] normally.
+- 💧 represents bytes, which are integers in the range of [-128,127] normally.
 
 The numeric literals we have seen above are converted to an appropriate type
 in accordance with [Type Expectations](types.html#type-expectations). This means


### PR DESCRIPTION
On the "Basics" page, it is claimed that the range of a 💧 is [-127, 127]. This is certainly a weird range for a byte, since it only allows 255 of the 256 values an actual byte can have.

The following test suggests that it's the documentation that's wrong:

```
🏁🍇
  🖍️🆕 byte 💧
  -128 ➡️🖍️byte
  😀🔡🔢byte❗ 10❗❗
🍉
```

Hence, this PR corrects the range for a byte.