### PR TITLE
Change 🍨  to 🍿 in list explanation paragraph

### DIFF
--- a/src/guides/compile-and-run.md
+++ b/src/guides/compile-and-run.md
@@ -75,7 +75,7 @@ greetings instead:
 🍉
 ```
 
-What happens here exactly? Everything that you list between `🍨` and `🍆` is made
+What happens here exactly? Everything that you list between `🍿` and `🍆` is made
 into a list. And `➡️` is used to create a constant variable. Maybe this appears
 odd at first, but in Emojicode the value for a variable is on the left-hand-side
 of `➡️` and the variable name on the right-hand-side.


### PR DESCRIPTION
Fixes #65 

I've tried out some code examples and they only seem to work when 🍿 is changed to 🍨 as is specified in the text `Everything that you list between 🍨 and 🍆 is made into a list`