### PR TITLE
Fix typo: wale -> whale

### DIFF
--- a/src/reference/typevalues.md
+++ b/src/reference/typevalues.md
@@ -97,7 +97,7 @@ instantiates them at run-time and calls a method on these instances:
   🔑 🆕 🍇 ⤴️🆕❗️ 🍉
 
   ✒️ ❗️ 🙋 🍇
-    😀 🔤I’m a wale.🔤❗️
+    😀 🔤I’m a whale.🔤❗️
   🍉
 🍉
 


### PR DESCRIPTION
Just a small typo.