### PR TITLE
Update base.scss to not show annoying scroll bar

### DIFF
--- a/src/static/css/base.scss
+++ b/src/static/css/base.scss
@@ -115,7 +115,7 @@ code {
 pre {
   padding: 1.3333rem;
   font-size: 16px;
-  overflow-x: scroll;
+  overflow-x: auto;
   position: relative;
 
   code {


### PR DESCRIPTION
Today, after visiting this page for about the fifth time, noticed the hello world example had a **glaring** flaw: a permanent *scroll bar*. I have taken the liberty to change this to `auto` so it only shows when there is overflowing content present. Enjoy.