### PR TITLE
👓 fix typo

### DIFF
--- a/src/packages/files/package.json
+++ b/src/packages/files/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "json",
+	"name": "files",
 	"author": "Theo Weidmann",
 	"version": "1.0",
 	"license": "Artistic 2.0"


### PR DESCRIPTION
files package is files package not json package

I'm hoping this fixes the bug I observe while browsing the documentation for files:
![image](https://user-images.githubusercontent.com/12286274/207913274-f54df95f-1bd6-4458-9c92-869a78b700e2.png)
![image](https://user-images.githubusercontent.com/12286274/207913401-b25c8a15-468c-41b8-a1b0-b57a4f506ac9.png)
