### PR TITLE
🍇 add favicon to documentation pages too

### DIFF
--- a/src/templates/main.mustache
+++ b/src/templates/main.mustache
@@ -4,6 +4,8 @@
     <link rel="stylesheet" href="https://thbwd.github.io/emojifont/emojicode.css">
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <link rel="icon" type="image/svg+xml" href="/static/img/favicon.svg" />
+    <link rel="icon" type="image/png" href="/static/img/favicon.png" />
 		<link href="/static/css/docs.css" rel="stylesheet" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@alpha" />
 		<title>Emojicode Documentation{{#title}} &middot; {{title}}{{/title}}</title>


### PR DESCRIPTION
I realized after #99 was merged that there still was no favicon in the docs such as <https://www.emojicode.org/docs/guides/compile-and-run.html>, although it does properly show up on the home page <https://www.emojicode.org/>. I added the favicon to the other main HTML file so that it should show up everywhere on the site.

![image](https://user-images.githubusercontent.com/12286274/208156319-992c42fe-4ce8-4635-b5a0-f73466616e53.png)
